### PR TITLE
Corrected the test for IncrementArbitaryPrecisionInteger

### DIFF
--- a/arrays/src/test/java/IncrementArbitraryPrecisionIntegerTest.java
+++ b/arrays/src/test/java/IncrementArbitraryPrecisionIntegerTest.java
@@ -2,6 +2,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 
@@ -12,22 +13,23 @@ public class IncrementArbitraryPrecisionIntegerTest {
 
     @Test
     public void incrementInteger1() {
-        input = Arrays.asList(1, 2, 9);
-        incremented = Arrays.asList(1, 3, 0);
+        input = getArrayList(new int[]{1, 2, 9});
+        incremented = getArrayList(new int[]{1, 3, 0});
+
         test(input,incremented);
     }
 
     @Test
     public void incrementInteger2() {
-        input = Arrays.asList(9,9,9,9,9,9,9);
-        incremented = Arrays.asList(0,0,0,0,0,0,0);
+        input = getArrayList(new int[]{9,9,9,9,9,9,9});
+        incremented = getArrayList(new int[]{1,0,0,0,0,0,0,0});
         test(input,incremented);
     }
 
     @Test
     public void incrementInteger3() {
-        input = Arrays.asList(8,9,9,9,9,9,9);
-        incremented = Arrays.asList(9,0,0,0,0,0,0);
+        input = getArrayList(new int[]{8,9,9,9,9,9,9});
+        incremented = getArrayList(new int[]{9,0,0,0,0,0,0});
         test(input,incremented);
     }
 
@@ -36,5 +38,10 @@ public class IncrementArbitraryPrecisionIntegerTest {
         assertEquals(incremented, input);
     }
 
-
+    private List<Integer> getArrayList(int[] arr) {
+        return Arrays.
+                stream(arr).
+                boxed().
+                collect(Collectors.toList());
+    }
 }


### PR DESCRIPTION
Existing test does not correctly validate the case where input is ```{9,9,9,9,9,9,9}```. The correct output should be ```{1,0,0,0,0,0,0,0}``` whereas currently the output is tested against ```{0,0,0,0,0,0,0}```.
It is not checking for the case where the output sum can exceed number of digits in input array. As the book states that in such a scenario, we should be adding another digit to output list.

The test curenltly creates input array using ```Arrays.asList()``` method which throws an ```java.lang.UnsupportedOperationException``` when we try to add a digit to the the array as  ```Arrays.asList()``` returns a fixed-size array which does not supports ```add``` operation. ([StackOverflow Thread](https://stackoverflow.com/questions/5755477/java-list-add-unsupportedoperationexception)). 

To resolve this, we can send an ```ArrayList``` which does support add. I have added a method to convert the primitive input array to an ```ArrayList```. 

