### PR TITLE
Bugfix in LRUCacheTest.java

### DIFF
--- a/hashtables/src/test/java/LRUCacheTest.java
+++ b/hashtables/src/test/java/LRUCacheTest.java
@@ -24,7 +24,7 @@ public class LRUCacheTest {
         assertNull(cache.lookup(2));
 
         //LRU IS NOW MOST RECENTLY ACCESSED
-        assertEquals(list.get(3), cache.lookup(3));
+        assertEquals(list.get(2), cache.lookup(3));
 
         //INSERT ONE AND BUMP OFF LAST ENTRY
         cache.insert(1, 1);


### PR DESCRIPTION
The list is `1, 2, 3, 4, 5, 6, 7, 8, 9, 10` and `list.get(3)` will return 4 which will not be equal to `cache.lookup(3)` having an expected value of 3. The correct check I assume should be `assertEquals(list.get(2), cache.lookup(3));` which pushed key 3 on top of recently accessed and `cache.insert(1, 1);` will pop of key 4 due to capacity exceeded. We assert for a null of key 4 in next step of test case.