### PR TITLE
Fixing invalid import.

### DIFF
--- a/graphs/src/test/java/ComputeShortestPathTest.java
+++ b/graphs/src/test/java/ComputeShortestPathTest.java
@@ -1,8 +1,6 @@
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.annotation.PostConstruct;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;


### PR DESCRIPTION
The import "javax.annotation.PostConstruct" is not necessary and also is not available in more recent versions of the JDK.